### PR TITLE
Supporto per soluzioni con espressioni regolari

### DIFF
--- a/bot/bot_telegram_dialogue.py
+++ b/bot/bot_telegram_dialogue.py
@@ -541,9 +541,12 @@ def state_DOMANDA(p, message_obj=None, **kwargs):
                         remaining = MIN_SEC_INDIZIO_1 - ellapsed
                         send_message(p, p.ux().MSG_TOO_EARLY.format(remaining))
             else:
-                correct_answers_upper = [x.strip() for x in current_indovinello['SOLUZIONI'].upper().split(',')]
+                import functools, re
+                soluzioni_list = current_indovinello['SOLUZIONI'].upper().split(',')
+                correct_answers_upper = [x.strip() for x in soluzioni_list if not (x.strip()[0] == '/' and x.strip()[-1] == '/')]
+                correct_answers_regex = [x.strip()[1:-1] for x in soluzioni_list if (x.strip()[0] == '/' and x.strip()[-1] == '/')]
                 #correct_answers_upper_word_set = set(flatten([x.split() for x in correct_answers_upper]))
-                if text_input.upper() in correct_answers_upper:
+                if text_input.upper() in correct_answers_upper or functools.reduce(lambda a, regex: a or re.compile(regex).match(text_input.upper()), correct_answers_regex, False):
                     game.set_end_mission_time(p)
                     if not send_post_message(p, current_indovinello):
                         send_message(p, bot_ux.MSG_ANSWER_OK(p.language), remove_keyboard=True)


### PR DESCRIPTION
In caso una soluzione ad una domanda inizi e termini per `/`, il sistema la considererà un'espressione regolare e considererà valida la risposta dell'utente qualora almeno un'espressione regolare sia ritenuta valida.

Per considerare valido un qualsiasi numero intero da 0 a 100 espresso in cifre, con tale modifica sarebbe sufficiente una singola soluzione `/\d{1,3}/` invece dei 100 singoli valori.

Sicuramente sarebbe una funzione utilizzata non tanto frequentemente, ma credo che possa semplificare notevolmente il lavoro di creazione di dataset.