### PR TITLE
Supporto per soluzioni con espressioni regolari - Risolti problemi segnalati da Federico

### DIFF
--- a/bot/bot_telegram_dialogue.py
+++ b/bot/bot_telegram_dialogue.py
@@ -541,12 +541,15 @@ def state_DOMANDA(p, message_obj=None, **kwargs):
                         remaining = MIN_SEC_INDIZIO_1 - ellapsed
                         send_message(p, p.ux().MSG_TOO_EARLY.format(remaining))
             else:
-                import functools, re
-                soluzioni_list = current_indovinello['SOLUZIONI'].upper().split(',')
-                correct_answers_upper = [x.strip() for x in soluzioni_list if not (x.strip()[0] == '/' and x.strip()[-1] == '/')]
-                correct_answers_regex = [x.strip()[1:-1] for x in soluzioni_list if (x.strip()[0] == '/' and x.strip()[-1] == '/')]
+                import functools, regex
+                soluzioni_list = regex.split(r"(?<!\\)(?:\\{2})*\K,", current_indovinello['SOLUZIONI'])
+                correct_answers_upper = [x.strip().upper() for x in soluzioni_list if not regex.match(r'^/.*/$', x)]
+                correct_answers_regex = [x[1:-1].replace('\\,',',') for x in soluzioni_list if regex.match(r'^/.*/$', x)]
+                for r in correct_answers_regex:
+                    try: regex.compile(r)
+                    except regex.error: correct_answers_regex.remove(r)
                 #correct_answers_upper_word_set = set(flatten([x.split() for x in correct_answers_upper]))
-                if text_input.upper() in correct_answers_upper or functools.reduce(lambda a, regex: a or re.compile(regex).match(text_input.upper()), correct_answers_regex, False):
+                if text_input.upper() in correct_answers_upper or functools.reduce(lambda a, r: a or regex.match(r, text_input, regex.I), correct_answers_regex, False):
                     game.set_end_mission_time(p)
                     if not send_post_message(p, current_indovinello):
                         send_message(p, bot_ux.MSG_ANSWER_OK(p.language), remove_keyboard=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pytz==2020.1
 PyYAML==5.4.1
 redis==3.5.3
 requests==2.24.0
+regex==2021.4.4
 rsa==4.7
 six==1.15.0
 toml==0.10.1


### PR DESCRIPTION
Fix in seguito alle segnalazioni di @kercos in #75 

Reso il matcher case insensitive.
Aggiunta la possibilità di fare l'escape di una virgola, al fine di includerla nella soluzione.
La stringa `/^\d{1\,3}$/` dovrebbe essere ora un regex matcher valido; permettendo l'inserimento di un qualsiasi numero da 1 a 3 cifre decimali.
In caso fosse necessario avere un backslash `\` prima di una virgola, sarà sufficiente fare l'escape dello stesso.
Aggiunta validazione dei pattern delle soluzioni: in caso uno risulti non valido, verrà semplicemente ignorato.
Per far funzionare `\K` (od eventualmente `(*PRUNE)`) correttamente, è necessario usare la libreria `regex` al posto della classica `re`.