### PR TITLE
Uniformare case su stringa errore prima di calcolare statistiche

### DIFF
--- a/historic/bot/airtable_utils.py
+++ b/historic/bot/airtable_utils.py
@@ -99,6 +99,7 @@ def get_wrong_answers(hunt_password, table_name='Results', output_file=None, out
     return mission_errors, errors_digested
 
 def process_errori(mission_error_dict):
+    mission_error_dict = [x.lower() for x in mission_error_dict]
     output = []
     # with open(output_file, 'w') as f_out:
     output.append("ERRORI piu' frequenti (Almeno 5 volte)\n")


### PR DESCRIPTION
C'erano errori tipo "Alabarda" e "alabarda" ed erano trattati separamente

l'aggiunta e' mission_error_dict = [x.lower() for x in mission_error_dict]

e l'ho fatta a caldo sul file senza avere modo di testare che sia corretta.